### PR TITLE
Added field array sorting (fixed flaky test)

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -135,7 +135,14 @@ public class WireMarshaller<T> {
     public static void getAllField(@NotNull Class clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
             getAllField(clazz.getSuperclass(), map);
-        for (@NotNull Field field : clazz.getDeclaredFields()) {
+        Field[] fields = clazz.getDeclaredFields();
+        Arrays.sort(fields, new Comparator<Field>() {
+            @Override
+            public int compare(Field o1, Field o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+        for (@NotNull Field field : fields) {
             if ((field.getModifiers() & (Modifier.STATIC | Modifier.TRANSIENT)) != 0)
                 continue;
             if ("ordinal".equals(field.getName()) && Enum.class.isAssignableFrom(clazz))


### PR DESCRIPTION
`addedEnum` test compares a string representation of an object to test if the object contains the correct values. The flakiness of the test comes from the fact that `toString` method relies on field array that is initialized when the objects are first created. This field array is obtained by calling [`getDeclaredFields` ](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)which is non-deterministic and can lead to different orders or field and value pairs. 

The fix for the flaky test is to first sort the field array during initialization of the object to give a deterministic result for `toString` comparison 